### PR TITLE
Update Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,20 +1,22 @@
 *
 
 !scripts/
+!*.nix
+!flake.lock
+!nix/
+!cabal.project
 
-!server/cabal.project
+!docs/static/ogmios.wsp.json
+
 !server/*.cabal
-
 !server/ogmios.wsp.json
 !server/LICENSE
-
 !server/app/
 !server/src/
 !server/static/
 !server/config/
 !server/test/
 server/test/vectors
-
 !server/modules/
 server/modules/**/.stack-work
 server/modules/hjsonpointer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,122 +1,50 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#                                                                              #
-# ------------------------------- SETUP  ------------------------------------- #
-#                                                                              #
 
-FROM haskell:8.10.4 as setup
-ARG CARDANO_NODE_REV=1.31.0
-# https://github.com/input-output-hk/iohk-nix/blob/master/overlays/crypto/libsodium.nix
-ARG IOHK_LIBSODIUM_GIT_REV=66f017f16633f2060db25e17c170c2afa0f2a8a1
-WORKDIR /build
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  automake=1:1.16.* \
-  build-essential=12.6 \
-  g++=4:8.3.* \
-  git=1:2.20.* \
-  libffi-dev=3.* \
-  libgmp-dev=2:6.1.* \
-  libpcre3-dev=2:8.* \
-  libncursesw5=6.* \
-  libssl-dev=1.1.* \
-  libsystemd-dev=241-* \
-  libtool=2.4.* \
-  make=4.2.* \
-  pkg-config=0.29-* \
-  zlib1g-dev=1:1.2.* \
-  && rm -rf /var/lib/apt/lists/*
+# Builder
+FROM nixos/nix:2.5.1 as builder
 
-RUN cabal update
+ARG CACHIX_KEY
+ARG CACHIX_CACHE
 
-# Build IOHK's libsodium fork, needed by cardano-node
-WORKDIR /app/src/libsodium
-RUN git clone https://github.com/input-output-hk/libsodium.git /app/src/libsodium &&\
-  git fetch --all --tags &&\
-  git checkout ${IOHK_LIBSODIUM_GIT_REV}
-WORKDIR /app/src/libsodium
-RUN ./autogen.sh && ./configure && make && make install
-ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+RUN echo -e "\
+experimental-features = nix-command flakes \n\
+substituters = https://hydra.iohk.io https://cache.nixos.org/ \n\
+trusted-public-keys = \
+    hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= \
+    cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= \
+" > /etc/nix/nix.conf
 
-# Build cardano-node.
-WORKDIR /app/src/cardano-node
-RUN git clone https://github.com/input-output-hk/cardano-node.git /app/src/cardano-node &&\
-  git fetch --all --tags &&\
-  git checkout ${CARDANO_NODE_REV}
-WORKDIR /app/src/cardano-node
-RUN cabal install cardano-node \
-  --overwrite-policy=always \
-  --install-method=copy \
-  --installdir=/app/bin
+WORKDIR /ogmios
+RUN nix shell nixpkgs\#git -c \
+  git clone --depth 1 https://github.com/input-output-hk/cardano-configurations.git
 
-#                                                                              #
-# --------------------------- BUILD (ogmios) --------------------------------- #
-#                                                                              #
+# See https://github.com/NixOS/nix/issues/5797, should be fixed in next
+# release
+RUN mkdir -p /etc/ssl/certs/ && ln -s $NIX_SSL_CERT_FILE /etc/ssl/certs/
 
-FROM setup as build
+WORKDIR /ogmios/server
+COPY . .
+RUN chmod +x scripts/cachix.sh && scripts/cachix.sh $CACHIX_CACHE $CACHIX_KEY
+RUN nix build -L .\#packages.x86_64-linux.ogmios-static
+RUN cp result/bin/ogmios .
 
-WORKDIR /app/src/ogmios/server
-
-COPY server/ .
-
-RUN cabal install exe:ogmios \
-  --overwrite-policy=always \
-  --install-method=copy \
-  --installdir=/app/bin
-
-WORKDIR /app
-RUN git clone --depth 1 https://github.com/input-output-hk/cardano-configurations.git
-
-#                                                                              #
-# --------------------------- RUN (ogmios-only) ------------------------------ #
-#                                                                              #
-
-FROM debian:buster-slim as ogmios
-
-LABEL name=ogmios
-LABEL description="A JSON WebSocket bridge for cardano-node."
-
-COPY --from=build /usr/local/lib/libsodium.so.23 /usr/lib/x86_64-linux-gnu/libsodium.so.23
-COPY --from=build /app/bin/ogmios /bin/ogmios
-
-RUN mkdir -p /etc/bash_completion.d
-RUN ogmios --bash-completion-script ogmios > /etc/bash_completion.d/ogmios
-RUN echo "source /etc/bash_completion.d/ogmios" >> ~/.bashrc
-
-EXPOSE 1337/tcp
-ENTRYPOINT ["ogmios"]
-
-#                                                                              #
-# --------------------- RUN (cardano-node & ogmios) -------------------------- #
-#                                                                              #
-
-FROM debian:buster-slim as cardano-node-ogmios
+# Run ogmios & cardano-node
+FROM inputoutput/cardano-node:1.31.0 as cardano-node-ogmios
 
 ARG NETWORK=mainnet
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-LABEL name=cardano-node-ogmios
-LABEL description="A JSON WebSocket bridge for cardano-node w/ a cardano-node."
-
-# Ogmios, cardano-node, ekg, prometheus
-EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
-
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  wget=1.20.1-* \
-  netbase=5.6 \
-  ca-certificates=20200601* \
-  && rm -rf /var/lib/apt/lists/*
-RUN apt-get -y purge && apt-get -y clean && apt-get -y autoremove
-
-COPY --from=setup /usr/local/lib/libsodium.so.23 /usr/lib/x86_64-linux-gnu/libsodium.so.23
-COPY --from=setup /app/bin/cardano-node /bin/cardano-node
-COPY --from=build /app/bin/ogmios /bin/ogmios
-COPY --from=build /app/cardano-configurations/network/${NETWORK} /config
+COPY --from=builder /ogmios/server/ogmios /bin/ogmios
+COPY --from=builder /ogmios/cardano-configurations/network/${NETWORK} /config
 
 RUN mkdir /ipc
 
 WORKDIR /root
 COPY scripts/cardano-node-ogmios.sh cardano-node-ogmios.sh
-CMD ["bash", "cardano-node-ogmios.sh" ]
+# Ogmios, cardano-node, ekg, prometheus
+EXPOSE 1337/tcp 3000/tcp 12788/tcp 12798/tcp
+STOPSIGNAL SIGINT
+ENTRYPOINT ["/root/cardano-node-ogmios.sh"]

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,9 @@
         inherit system;
       };
 
-      projectFor = system:
+      # `static` enables cross-compilation with musl64 to produce a statically
+      # linked `ogmios` executable
+      projectFor = { system, static ? false }:
         let
           pkgs = nixpkgsFor system;
           plutus = import plutusSrc { inherit system; };
@@ -62,19 +64,27 @@
           src = fakeSrc.outPath;
         in
         import ./nix/haskell.nix {
-          inherit src pkgs plutus system;
+          inherit src pkgs plutus system static;
         };
 
     in
     {
-      flake = perSystem (system: (projectFor system).flake { });
+      flake = perSystem (system: (projectFor { inherit system; }).flake { });
 
-      defaultPackage = perSystem (
-        system:
+      flake-static = perSystem (system:
+        (projectFor { inherit system; static = true; }).flake { }
+      );
+
+      defaultPackage = perSystem (system:
         self.flake.${system}.packages."ogmios:exe:ogmios"
       );
 
-      packages = perSystem (system: self.flake.${system}.packages);
+      packages = perSystem (system:
+        self.flake.${system}.packages // {
+          static-ogmios =
+            self.flake-static.${system}.packages."ogmios:exe:ogmios";
+        }
+      );
 
       apps = perSystem (system: self.flake.${system}.apps);
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
 
       packages = perSystem (system:
         self.flake.${system}.packages // {
-          static-ogmios =
+          ogmios-static =
             self.flake-static.${system}.packages."ogmios:exe:ogmios";
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
           {
             nativeBuildInputs =
               builtins.attrValues self.checks.${system}
-              ++ builtins.attrValues self.packages.${system};
+              ++ builtins.attrValues self.flake.${system}.packages;
           } "touch $out"
       );
 

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -19,7 +19,6 @@ let
 
     name = "ogmios";
 
-    # Plutus uses a patched GHC. And so shall we.
     compiler-nix-name = "ghc8107";
 
     shell = {

--- a/scripts/cachix.sh
+++ b/scripts/cachix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -n "$1" ]]; then
+    # `nix profile install` doesn't work??
+    nix-env -iA nixpkgs.cachix
+    if [[ -n "$2" ]]; then cachix authtoken "$2"; fi
+    cachix use "$1"
+fi


### PR DESCRIPTION
- Replaces the existing Dockerfile with one based on our Nix setup
- Enables additional `CACHIX_CACHE` and `CACHIX_KEY` Docker build args to optionally build with Cachix inside the container, e.g.
   ```
   $ docker build --build-arg CACHIX_CACHE=somecache .
   ```
- Adds a statically linked `ogmios` executable as an additional target in the `packages` output (used in the Dockerfile, can be built with `nix build .#packages.x86_64-linux.ogmios-static`)

The compiler version has also been changed to 8.10.7 to enable static compilation. This is what upstream uses, though